### PR TITLE
Added CF Dev plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -427,6 +427,30 @@ plugins:
   updated: 2016-04-11T00:00:00Z
   version: 1.1.0
 - authors:
+  - contact: ssisil@pivotal.io
+    name: Scott Sisil
+  - contact: slevine@pivotal.io
+    name: Stephen Levine
+  - contact: ecasey@pivotal.io
+    name: Emily Casey
+  - contact: shiehn@pivotal.io
+    name: Stephen Hiehn
+  - contact: dgoddard@pivotal.io
+    name: David Goddard
+  - contact: avoellmer@pivotal.io
+    name: Andy Voellmer
+  binaries:
+  - checksum: f1466cad5342e0acd1f7cbe680639458b5794e07
+    platform: osx
+    url: https://d3p1cc0zb2wjno.cloudfront.net/cfdev/cfdev-v0.0.5-darwin
+  company: Pivotal
+  created: 2018-05-23T00:00:00Z
+  description: Run Cloud Foundry in your local environment
+  homepage: https://github.com/cloudfoundry-incubator/cfdev
+  name: cfdev
+  updated: 2018-05-23T00:00:00Z
+  version: 0.0.5
+- authors:
   - contact: stephen.levine@gmail.com
     homepage: https://github.com/sclevine
     name: Stephen Levine


### PR DESCRIPTION
Added CF Dev plugin to the cli-plugin-repo.  We currently only support a macOS version of the plugin, but plan to add Windows and Linux versions in the near future.