### PR TITLE
remove reference to deprecated networking plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1020,25 +1020,6 @@ plugins:
   updated: 2018-06-12T00:00:00Z
   version: 0.3.0
 - authors:
-  - name: CF Networking Team
-  binaries:
-  - checksum: 56b9854a55265c9a693fd2ab77cbbdfdada1ee53
-    platform: osx
-    url: https://github.com/cloudfoundry-incubator/cf-networking-release/releases/download/v1.6.1/network-policy-plugin-darwin64
-  - checksum: 6aa26fc0be0c446b87dd436591ac234b3bad697d
-    platform: win64
-    url: https://github.com/cloudfoundry-incubator/cf-networking-release/releases/download/v1.6.1/network-policy-plugin-windows64.exe
-  - checksum: 2dd83782f0c4ff11ed95104da48197e53dd362c4
-    platform: linux64
-    url: https://github.com/cloudfoundry-incubator/cf-networking-release/releases/download/v1.6.1/network-policy-plugin-linux64
-  company: Pivotal
-  created: 2017-07-10T00:00:00Z
-  description: Allow the user to manage application network policies
-  homepage: https://github.com/cloudfoundry-incubator/cf-networking-release
-  name: network-policy
-  updated: 2017-11-03T18:54:18Z
-  version: 1.6.1
-- authors:
   - contact: long@starkandwayne.com
     homepage: http://lnguyen.io
     name: Long Nguyen


### PR DESCRIPTION
- the core cli now has the network-policy functionality

[#160364892]

Signed-off-by: Christian Ang <cang@pivotal.io>