### PR TITLE
Make plugin names anchors so that individual plugins can be linked to

### DIFF
--- a/ui/css/cff.css
+++ b/ui/css/cff.css
@@ -43,7 +43,7 @@ ul.list-of-links li {
   padding: 2px 8px;
 }
 
-a.permalink {
+.permalink {
   display: none;
 }
 

--- a/ui/css/cff.css
+++ b/ui/css/cff.css
@@ -42,3 +42,11 @@ ul.list-of-links li {
   border: none !important;
   padding: 2px 8px;
 }
+
+a.permalink {
+  display: none;
+}
+
+.permalinkHoverable:hover .permalink {
+  display: inline;
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -48,8 +48,11 @@
         <div class="col-xs-18 col-sm-18 col-md-18 col-lg-18 bg-neutral-11 phxxxl">
           <div ng-repeat="plugin in list.plugins">
             <div class="mtxxl"></div>
-            <h3 class="name" style="display: inline-block">{{plugin.name}}</h3>
-            <span class="version type-sm" ng-if="plugin.version != ''"> &ndash; v.{{plugin.version}}</span>
+            <span class="permalinkHoverable">
+              <h3 class="name" style="display: inline-block" id="{{plugin.name}}">{{plugin.name}}</h3>
+              <span class="version type-sm" ng-if="plugin.version != ''"> &ndash; v.{{plugin.version}}</span>
+              <a class="permalink" href="#{{plugin.name}}"><h3 class="name" style="display: inline-block">&para;</h3></a>
+            </span>
             <p class="date pull-right mvl type-sm type-neutral-4" ng-bind="plugin.updated | date:'MM/dd/yyyy'"></p>
             <p class="description mtl" style="white-space: pre-line">
               {{plugin.description}}

--- a/ui/index.html
+++ b/ui/index.html
@@ -48,11 +48,11 @@
         <div class="col-xs-18 col-sm-18 col-md-18 col-lg-18 bg-neutral-11 phxxxl">
           <div ng-repeat="plugin in list.plugins">
             <div class="mtxxl"></div>
-            <span class="permalinkHoverable">
+            <a href="#{{plugin.name}}" class="permalinkHoverable">
               <h3 class="name" style="display: inline-block" id="{{plugin.name}}">{{plugin.name}}</h3>
               <span class="version type-sm" ng-if="plugin.version != ''"> &ndash; v.{{plugin.version}}</span>
-              <a class="permalink" href="#{{plugin.name}}"><h3 class="name" style="display: inline-block">&para;</h3></a>
-            </span>
+              <span class="permalink"><h3 class="name" style="display: inline-block">&para;</h3></span>
+            </a>
             <p class="date pull-right mvl type-sm type-neutral-4" ng-bind="plugin.updated | date:'MM/dd/yyyy'"></p>
             <p class="description mtl" style="white-space: pre-line">
               {{plugin.description}}


### PR DESCRIPTION
Show para icon when hovering over header, in the same manner as
godoc.org does.