### PR TITLE
Add cf-report-usage-plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -389,6 +389,33 @@ plugins:
   updated: 2018-10-24T16:54:34Z
   version: 1.1.1
 - authors:
+  - contact: aegershman+github@gmail.com
+    homepage: https://github.com/aegershman
+    name: Aaron Gershman
+  binaries:
+  - checksum: 0ec5a4b3e555dcc0a7fb069bee22a2cd1675b019
+    platform: linux32
+    url: https://github.com/aegershman/cf-report-usage-plugin/releases/download/2.12.0/cf-report-usage-plugin-linux-386
+  - checksum: cfd705845edba0922d633e76d685dbfa48e63e2e
+    platform: linux64
+    url: https://github.com/aegershman/cf-report-usage-plugin/releases/download/2.12.0/cf-report-usage-plugin-linux-amd64
+  - checksum: 7003a567c05e9527654617ab25ffd07919cbe71f
+    platform: win32
+    url: https://github.com/aegershman/cf-report-usage-plugin/releases/download/2.12.0/cf-report-usage-plugin-windows-386.exe
+  - checksum: 6dd22324519a9f704c4d005812d5f57c79a880ee
+    platform: win64
+    url: https://github.com/aegershman/cf-report-usage-plugin/releases/download/2.12.0/cf-report-usage-plugin-windows-amd64.exe
+  - checksum: 83d95653465894f2b7fdafa8e612228311758c50
+    platform: osx
+    url: https://github.com/aegershman/cf-report-usage-plugin/releases/download/2.12.0/cf-report-usage-plugin-darwin
+  company: null
+  created: 2019-12-03T00:00:00Z
+  description: cf-cli plugin for creating reports of AI/SI usage
+  homepage: https://github.com/aegershman/cf-report-usage-plugin
+  name: cf-report-usage-plugin
+  updated: 2019-12-06T00:00:00Z
+  version: 2.12.0
+- authors:
   - contact: Winston_R_Milling@homedepot.com
     homepage: https://github.com/wrmilling
     name: Winston R. Milling


### PR DESCRIPTION
## Description of the Change

Initial PR for cf-report-usage-plugin. This plugin is a fork of the [trueupreport-plugin](https://github.com/jigsheth57/trueupreport-plugin), which is a fork of the [usagereport-plugin](https://github.com/krujos/usagereport-plugin). It shares the same `git` history with both (with the exception that I ran over it's history to purge files larger than 1MB to save on size & operation time.)

Maybe I'm being too aggressive, but it looks like the upstream repos this is forked from aren't maintained/haven't been touched year(s). I reached out on both repos and didn't hear a response (again, maybe didn't try hard enough / was too aggressive?), but figured I'd be better off just forking and speeding ahead.

## Why Is This PR Valuable?

This fork cleans up internal plugin architecture (I think), leverages `gomodules`, a release process with `goreleaser`, adds more presentation format options than the `string` output-- including a `json` output useful for feeding the data into other systems via cli-- supports aggregating multiple orgs, and importantly, distinguishes between "AIs" and "App Deployments", "AIs" and "Billable AIs" (as according to Pivotal-- making this more configurable is a feature I'd like to improve in the future), etc.

## How Urgent Is The Change?

very little, to be honest

## Other Relevant Parties

- [trueupreport-plugin](https://github.com/jigsheth57/trueupreport-plugin)
- [usagereport-plugin](https://github.com/krujos/usagereport-plugin)

Thanks for any time / consideration!

EDIT I'll come back to this later. I realize there's lot's of improvements I could make in the mean time to having this merged in.