### PR TITLE
cf-reverse-service-lookup-plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -389,6 +389,33 @@ plugins:
   updated: 2018-10-24T16:54:34Z
   version: 1.1.1
 - authors:
+  - contact: aegershman+github@gmail.com
+    homepage: https://github.com/aegershman
+    name: Aaron Gershman
+  binaries:
+  - checksum: 8058c37349c8d312b2b1bf8659d033d0b426f043
+    platform: linux32
+    url: https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.2.0/cf-reverse-service-lookup-plugin-linux-386
+  - checksum: f7ef035c5e4dc9dcbdbc69885f8b7afe11615fb0
+    platform: linux64
+    url: https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.2.0/cf-reverse-service-lookup-plugin-linux-amd64
+  - checksum: 7248d4af01505e58910ee2c85dad71a190610662
+    platform: win32
+    url: https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.2.0/cf-reverse-service-lookup-plugin-windows-386.exe
+  - checksum: 7edceacba35b7d5768b8659c5c4dad9436630b84
+    platform: win64
+    url: https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.2.0/cf-reverse-service-lookup-plugin-windows-amd64.exe
+  - checksum: 4742a3e0c6ac9e4002c60ec82f4aa3dd6b8bfe83
+    platform: osx
+    url: https://github.com/aegershman/cf-reverse-service-lookup-plugin/releases/download/0.2.0/cf-reverse-service-lookup-plugin-darwin
+  company: null
+  created: 2019-12-04T00:00:00Z
+  description: cf-cli plugin to perform reverse lookups against service instance GUIDs
+  homepage: https://github.com/aegershman/cf-reverse-service-lookup-plugin
+  name: cf-reverse-service-lookup-plugin
+  updated: 2019-12-04T00:00:00Z
+  version: 0.2.0
+- authors:
   - contact: Winston_R_Milling@homedepot.com
     homepage: https://github.com/wrmilling
     name: Winston R. Milling


### PR DESCRIPTION
## Description of the Change

[submitting index listing for `cf-reverse-service-lookup-plugin`](https://github.com/aegershman/cf-reverse-service-lookup-plugin)

## Why Is This PR Valuable?

This plugin aims to map between how BOSH references service deployments, e.g. service-instance_GUID, and how they're referenced in Cloud Foundry. It can be frustrating when tools like the bosh-cli and Prometheus/Alertmanager start yelling about a service instance barfing, but you have to spend time going through this whole riggamarole of looking up the service to see which org/space it belongs to, etc.

With this plugin, as long as you're logged into the same Cloud Foundry installation as the service-instance_GUID you're trying to find, this will go through the whole riggamarole of looking up the org/space of the service instance for you.

## How Urgent Is The Change?

nah brah 🤙 no worries, no rush

## Other Relevant Parties

n/a

## miscellaneous

this PR is quick replacement of the original (https://github.com/cloudfoundry/cli-plugin-repo/pull/329) except I renamed it to cf-reverse-service-lookup-plugin. I realized a short while after using it daily that "service-reverse-lookup" isn't as intuitive, so I renamed it to this. Those are the only changes.

EDIT I'll come back to this later. I realize there's lot's of improvements I could make in the mean time to having this merged in.