### PR TITLE
UPDATE CF-Puppeteer Version to 1.2.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -350,23 +350,23 @@ plugins:
     homepage: https://github.com/HappyTobi
     name: Tobias Schug
   binaries:
-  - checksum: c6adf394aeffcc12a5ae0aa2d63d8533edf01b3c
+  - checksum: 0f73d1046a3f7461ad78a0e9612744c612536b10
     platform: osx
-    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.1.3/cf-puppeteer-darwin
-  - checksum: 2ad9138128590ba5b84b3e0f0a1864dc61155310
+    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.2.0/cf-puppeteer-darwin
+  - checksum: 3507e354dbb10381fe6eba1cef6730f9c56c112b
     platform: win64
-    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.1.3/cf-puppeteer.exe
-  - checksum: 26e07d59a734ec8a1abdff4266c5329988233b0f
+    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.2.0/cf-puppeteer.exe
+  - checksum: c18d09ca3a2427cab66cdc7d455b9f303e4c1199
     platform: linux64
-    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.1.3/cf-puppeteer-linux
+    url: https://github.com/HappyTobi/cf-puppeteer/releases/download/1.2.0/cf-puppeteer-linux
   company: null
   created: 2019-01-17T00:00:00Z
   description: Perform a zero-downtime restage of an application over the top of an
     old one
   homepage: https://cf-puppeteer.happytobi.com
   name: cf-puppeteer
-  updated: 2019-11-26T00:00:00Z
-  version: 1.1.3
+  updated: 2020-02-24T00:00:00Z
+  version: 1.2.0
 - authors:
   - contact: https://twitter.com/superbeeny
     homepage: https://github.com/superbeeny


### PR DESCRIPTION
Update CF-Puppeteer to new Version 1.2.0

Some new features are implemented (--vars-file option was back)
Fix some bugs while using the legacy option (--legacy-push)

The rest explained in the Blog and the Changelog file.

Kind Regards
