### PR TITLE
Add ApplicationDataBackupRestore cli plugin for Tanzu MySQL service

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1883,3 +1883,28 @@ plugins:
   name: wildcard_plugin
   updated: 2015-07-02T00:00:00Z
   version: 1.0.0
+- authors:
+  - name: CF Dedicated MySQL
+  binaries:
+  - checksum: 7cf54c0fe2bf032e96a7b7dce883f1ecc671517f
+    platform: osx
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.2.0/adbr-plugin-darwin-amd64
+  - checksum: 490146fe360a66604676b4f716876b3493a51cad
+    platform: linux32
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.2.0/adbr-plugin-linux-386
+  - checksum: b0bb278b30cd21ee68a852cda56f5f94cc1760a7
+    platform: linux64
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.2.0/adbr-plugin-linux-amd64
+  - checksum: db2870cebb4931e2099d3b8277c01d216320d2dd
+    platform: win32
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.2.0/adbr-plugin-windows-386.exe
+  - checksum: bba99a9095740779dc4501d92545295084c8bb13
+    platform: win64
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.2.0/adbr-plugin-windows-amd64.exe
+  company: VMware
+  created: 2020-08-11T00:00:00Z
+  description: Tool to backup/restore Tanzu MySQL service instances
+  homepage: https://docs.pivotal.io//p-mysql/backup-restore.html
+  name: ApplicationDataBackupRestore
+  updated: 2020-08-13T17:25:41Z
+  version: 0.2.0


### PR DESCRIPTION
[#174235339](https://www.pivotaltracker.com/story/show/174235339)

Signed-off-by: Kai Xiang <kxiang@pivotal.io>

Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

This change adds a new cf cli plugin ApplicationDataBackupRestore which will enable the user to backup and restore for Tanzu MySQL service instances using cf command.


## Why Is This PR Valuable?

This enable Cody(application developer) to do self-service backup/restore without relying Alana(PCF operator), which simplify the process of backup/restore for Tanzu MySQL service.


## Applicable Issues

N/A

## How Urgent Is The Change?

This blocks our release of the new Tanzu MySQL service, which we are hoping to release in a week or two.

## Other Relevant Parties

N/A
