### PR TITLE
bump log-cache-cli

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1079,7 +1079,7 @@ plugins:
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
   updated: 2019-01-28T00:00:00Z
-  version: 2.1.0
+  version: 3.1.0
 - authors:
   - name: CF Loggregator Team
   binaries:

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1064,15 +1064,15 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: 64f000980fd7ff309aa9d5690a405795733c6640
+  - checksum: 39a45c9926d0c4de3dc0fb9aad71bd2ea354b24c
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.1.0/log-cache-cf-plugin-darwin
-  - checksum: 5cd45360101a60f261d6dbff20bb8bead78bf85e
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v3.1.0/log-cache-cf-plugin-darwin
+  - checksum: 826dd5e91f15a197bfea277ce80822cb4b2bc980
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.1.0/log-cache-cf-plugin-linux
-  - checksum: 182562eddf8ab2776dad3fbe0104a429a555e292
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v3.1.0/log-cache-cf-plugin-linux
+  - checksum: 930e52f918a95dba1ea5a1c97cf444538e9407dd
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.1.0/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v3.1.0/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.


### PR DESCRIPTION
Signed-off-by: Jacob Schuenke <jschuenke@pivotal.io>

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

We've updated the log-meta --noise command to use metadata rather than actually counting envelopes to make it more reliable and performant.

## Why Is This PR Valuable?

It improves the usability for users with large foundations.

## Applicable Issues

N/A

## How Urgent Is The Change?

Yes, there are several users that require this change to properly test their foundations.

## Other Relevant Parties

Who else is affected by the change?

No one.