### PR TITLE
CF-Restage-All

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -414,6 +414,34 @@ plugins:
   updated: 2018-10-24T16:54:34Z
   version: 1.1.1
 - authors:
+  - contact: justin.klein@gm.com
+    homepage: https://github.com/generalmotors/cf-restage-all
+    name: Justin Klein
+  binaries:
+  - checksum: 936c75ba8b059b326104294704d289a8b0db1141
+    platform: osx
+    url: https://github.com/generalmotors/cf-restage-all/releases/download/1.0.0/cf-restage-all-amd64-darwin
+  - checksum: a8f555d182b1178c76c114e04fd445dad9596b56
+    platform: win32
+    url: https://github.com/generalmotors/cf-restage-all/releases/download/1.0.0/cf-restage-all-386-windows.exe
+  - checksum: b372a27efbd5ac9f1e424d9ada01ef640f5e0f7c
+    platform: win64
+    url: https://github.com/generalmotors/cf-restage-all/releases/download/1.0.0/cf-restage-all-amd64-windows.exe
+  - checksum: c2eec81a51a4ba67f492c4a194efc63613abfe17
+    platform: linux32
+    url: https://github.com/generalmotors/cf-restage-all/releases/download/1.0.0/cf-restage-all-386-linux
+  - checksum: 899793cca9d3446bab07652a5fb620737322703a
+    platform: linux64
+    url: https://github.com/generalmotors/cf-restage-all/releases/download/1.0.0/cf-restage-all-amd64-linux
+  company: General Motors
+  created: 2020-11-24T18:41:19Z
+  description: CF plugin for restaging all applications within an pcf space with minimal
+    downtime.
+  homepage: https://github.com/generalmotors/cf-restage-all
+  name: cf-restage-all
+  updated: 2020-11-24T18:41:19Z
+  version: 1.0.0
+- authors:
   - contact: Winston_R_Milling@homedepot.com
     homepage: https://github.com/wrmilling
     name: Winston R. Milling


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [ ] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [ ] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

This is the initial launch of the restage all plugin. This allows for all applications (with filters) to be restaged within a particular space within a foundation. This was created out of a need from General Motors and wanted to share back with the general community.


## Why Is This PR Valuable?

This allows for mass restaging within a PCF space. This is able to loop through all applications based on state and age of last droplet creation. This is important for buildpack refresh. Instead of running a restage command we are able to assign the droplet first and do a restart to help minimize downtime. We are currently using this within General Motors.

## Applicable Issues

None

## How Urgent Is The Change?

None

## Other Relevant Parties

None
