### PR TITLE
Update MysqlTools version to 0.9.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1286,29 +1286,29 @@ plugins:
 - authors:
   - name: CF Dedicated MySQL
   binaries:
-  - checksum: 1fbe0949aedea6bf6a46d3a7d0b4d13ab02fbb5a
+  - checksum: a5c3fe0cfcfb10ac4aef3e729f2e9ab464e99017
     platform: osx
-    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.8.0/mysql-plugin-darwin-amd64
-  - checksum: 52e7bd71ac2277fcaf05b15a17bf4676dea1978e
+    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.9.0/mysql-plugin-darwin-amd64
+  - checksum: 046f8e1145fd0d56019c4332e59e2c0e519f0712
     platform: linux32
-    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.8.0/mysql-plugin-linux-386
-  - checksum: c827bfc890d8051fa8d52e17c38972321668b99d
+    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.9.0/mysql-plugin-linux-386
+  - checksum: 4e1e23cccc7e957b59b1fc4f481bbf42566cb686
     platform: linux64
-    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.8.0/mysql-plugin-linux-amd64
-  - checksum: 1983287bb201bfdd512a0c3e020142d2ea9bd877
+    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.9.0/mysql-plugin-linux-amd64
+  - checksum: 87ec90bba7401ff97fbb9a398538e065309ebe16
     platform: win32
-    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.8.0/mysql-plugin-windows-386.exe
-  - checksum: cea957439ebe81e1d660545d6e8580bde3e5726b
+    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.9.0/mysql-plugin-windows-386.exe
+  - checksum: f52d2d524877e6c59091185c55e8b8e358cd37df
     platform: win64
-    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.8.0/mysql-plugin-windows-amd64.exe
+    url: https://github.com/pivotal-cf/mysql-cli-plugin/releases/download/v0.9.0/mysql-plugin-windows-amd64.exe
   company: Pivotal
   created: 2018-05-12T00:00:00Z
   description: Tool to migrate MySQL service instances from PCF MySQL v1 to PCF MySQL
     v2
   homepage: https://github.com/pivotal-cf/mysql-cli-plugin
   name: MysqlTools
-  updated: 2020-04-07T23:13:22Z
-  version: 0.8.0
+  updated: 2021-05-13T21:40:58Z
+  version: 0.9.0
 - authors:
   - contact: long@starkandwayne.com
     homepage: http://lnguyen.io


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [ ] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [ ] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing?

- Upgraded mysql and mysqldump client utilities to 5.7.33
- Addressed an error message where mysqldump attempts to access the tablespace information in the FILES table. We use the --no-tablespaces option to prevent accessing the tablespace information since the necessary privileges are not provided.


## Applicable Issues

List any applicable Github Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change?
