### PR TITLE
Bump log-cache plugin to v4.0.4

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1119,22 +1119,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: a6aa072c146f7898e13a05c4c143b66c1921a1be
+  - checksum: c463f83d5b3f66a92ed53508418e4439930a99fa
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.3/log-cache-cf-plugin-darwin
-  - checksum: 99bca78caea1d8708567e5c171fff86105fb846f
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.4/log-cache-cf-plugin-darwin
+  - checksum: dee1f4c0d1874ebe665c703f1ac2d48541173ffa
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.3/log-cache-cf-plugin-linux
-  - checksum: 6cd8c3816a6d8b6a13a31a155fba56e26f7cde0d
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.4/log-cache-cf-plugin-linux
+  - checksum: 1b1d62f047a6a74940f774a3812750ff65e3a028
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.3/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.4/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2021-12-21T00:00:00Z
-  version: 4.0.3
+  updated: 2022-03-01T00:00:00Z
+  version: 4.0.4
 - authors:
   - name: CF Loggregator Team
   binaries:


### PR DESCRIPTION
# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

Make the log-cache cf CLI plugin v4.0.4 available, which bumps dependencies for stability and is compiled with go1.18.

## Why Is This PR Valuable?

Bumping to go1.18 ahead of the go1.17 EOGS ~August.

## Applicable Issues

N/A

## How Urgent Is The Change?

Not very urgent.

## Other Relevant Parties

N/A