### PR TITLE
Update ApplicationDataBackupRestore cli plugin version to 0.4.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -96,28 +96,28 @@ plugins:
 - authors:
   - name: CF Dedicated MySQL
   binaries:
-  - checksum: df9ab34a8173a3f3b51c2afb9e5624ebb399847a
+  - checksum: ede787427180271564b48966a1f09591006a24ee
     platform: osx
-    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.3.0/adbr-plugin-darwin-amd64
-  - checksum: 28ab9e9349c11a9cad2483d9b07c6f550e98de2f
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.4.0/adbr-plugin-darwin-amd64
+  - checksum: 7fa5c548f2143174fe622b46887c31b2a45a47d2
     platform: linux32
-    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.3.0/adbr-plugin-linux-386
-  - checksum: 7d1fd08e006bbbd82cb72dca2baeefc092d70a15
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.4.0/adbr-plugin-linux-386
+  - checksum: 166781a31b40ace463e6d40dc4093928496e1397
     platform: linux64
-    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.3.0/adbr-plugin-linux-amd64
-  - checksum: 217d0648ffef0a7ce628f6a7d591b7b7652d8ac5
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.4.0/adbr-plugin-linux-amd64
+  - checksum: 50dabf89204af90d96f0a2baa393d54625224acf
     platform: win32
-    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.3.0/adbr-plugin-windows-386.exe
-  - checksum: db8dafc05b8aa2e74186502bd704dab078baa54a
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.4.0/adbr-plugin-windows-386.exe
+  - checksum: a9010b04e10a1b79f7fc8f86bbe003b470fe0b98
     platform: win64
-    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.3.0/adbr-plugin-windows-amd64.exe
+    url: https://adbr-cli-plugin-public.s3-us-west-1.amazonaws.com/0.4.0/adbr-plugin-windows-amd64.exe
   company: VMware
   created: 2020-08-11T00:00:00Z
   description: Tool to backup/restore Tanzu MySQL service instances
   homepage: https://docs.pivotal.io//p-mysql/backup-restore.html
   name: ApplicationDataBackupRestore
-  updated: 2021-05-26T17:28:44Z
-  version: 0.3.0
+  updated: 2022-04-01T00:49:12Z
+  version: 0.4.0
 - authors:
   - name: Christopher Brown
   binaries:


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [X] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [X] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

Update help text to accurately reflect command

Previously help was showing `cf adbr status` but the "real" command is `cf adbr get-status`


## Why Is This PR Valuable?

To help reduce user confusion - this bug came up based on a support engineer providing feedback from working with a customer


## Applicable Issues

NA

## How Urgent Is The Change?

Not especially urgent - current risk is low, and the functionality works fine, so this is just about being more clear / accurate in the documentation from `cf help`

## Other Relevant Parties

NA
