### PR TITLE
add new UpgradeAllServices plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -2001,3 +2001,20 @@ plugins:
   name: wildcard_plugin
   updated: 2015-07-02T00:00:00Z
   version: 1.0.0
+- authors:
+  - name: James Norman
+  - name: Felisia Martini
+  - name: George Blue
+  binaries:
+  - checksum: f6e48431f0063e66875b8df876a15660c2de5173
+    platform: osx
+    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.0.1/upgrade-all-services-cli-plugin_darwin_amd64
+  - checksum: 51c85b0b9de17bc8d9fe2a7ce33b95896efd496c
+    platform: linux64
+    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.0.1/upgrade-all-services-cli-plugin_linux_amd64
+  created: 2022-07-07T00:00:00Z
+  description: Allows a user to upgrade all the service instances for a service broker
+  homepage: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin
+  name: UpgradeAllServices
+  updated: 2022-07-07T00:00:00Z
+  version: 1.0.1


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

This add a new plugin, which is an extension of the "cf upgrade-service" command which upgrades only a single service at a time. This extension allows all the service instances for a particular broker to be upgraded via the syntax "cf upgrade-all-services <broker name>".

## Why Is This PR Valuable?

It is designed to be used by a system administrator who has given the services owners time to upgrade in their own time, and wants to mop up any services that have not yet been upgraded. It will save administrators time in manual typing, or writing their own script.


## Applicable Issues

None.

## How Urgent Is The Change?

Not urgent.

## Other Relevant Parties

None.

Who else is affected by the change?

This plugin was written to assist with users of the [Cloud Service Broker](https://github.com/cloudfoundry/cloud-service-broker), but our aim was to make it generic so that it would work with any broker.
