### PR TITLE
Delete depreciated cf security plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -470,27 +470,6 @@ plugins:
   updated: 2019-05-23T17:38:00Z
   version: 1.1.1
 - authors:
-  - contact: arthur.halet@orange.com
-    homepage: https://github.com/ArthurHlt
-    name: Arthur Halet
-  binaries:
-  - checksum: ca7fcaffba6c7af49dc4ad2e355567add7aba098
-    platform: osx
-    url: https://github.com/orange-cloudfoundry/cf-security-entitlement/releases/download/v0.1.12/cfsecurity-plugin_darwin_amd64
-  - checksum: 0bc64702ddb4616fec13a4404e0563e817b634f2
-    platform: win64
-    url: https://github.com/orange-cloudfoundry/cf-security-entitlement/releases/download/v0.1.12/cfsecurity-plugin_windows_amd64.exe
-  - checksum: 50b53733dc54e895d5ea9204cbe62681121366eb
-    platform: linux64
-    url: https://github.com/orange-cloudfoundry/cf-security-entitlement/releases/download/v0.1.12/cfsecurity-plugin_linux_amd64
-  company: Orange
-  created: 2019-07-12T00:00:00Z
-  description: Plugin to help usage of cf-security-entitlement
-  homepage: https://github.com/orange-cloudfoundry/cf-security-entitlement
-  name: cf-security-entitlement
-  updated: 2020-12-16T00:00:00Z
-  version: 0.1.12
-- authors:
   - homepage: https://github.com/gambtho
     name: Thomas Gamble
   binaries:


### PR DESCRIPTION
This PR will delete cf-security-entitlement plugin because this version is depreciated and we won't update anymore.
So to avoid the use of an old version we would like to delete it. 

Thanks. 