### PR TITLE
Bump metric-registrar plugin to v1.3.7

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1221,28 +1221,28 @@ plugins:
 - authors:
   - name: CF Metric Registrar Team
   binaries:
-  - checksum: a16819687d8479688c1c689f1e2aabe1e25cad9e
+  - checksum: ac07123172b50265887dccadeecaf3a40273f50c
     platform: osx
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.6/metric-registrar-cli-darwin-amd64-1.3.6
-  - checksum: 3944a8192da28bdb861646a9c4fb86bfc28edcd2
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-darwin-amd64-1.3.7
+  - checksum: d9c1140de72550801568233cebc9d26ba95454b2
     platform: win64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.6/metric-registrar-cli-windows-amd64-1.3.6
-  - checksum: 1994b473c3b3a0b1ededee65e262ccc4a55840bc
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-windows-amd64-1.3.7
+  - checksum: a37a779a248d254fc0bd7e110fe7d8aedaa12396
     platform: win32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.6/metric-registrar-cli-windows-386-1.3.6
-  - checksum: 6b36930725b343afb36da794af924f8c051afb77
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-windows-386-1.3.7
+  - checksum: daba53e7610d18c328e5dede8ddb4b9584a6f8d4
     platform: linux64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.6/metric-registrar-cli-linux-amd64-1.3.6
-  - checksum: 8f3a62d13f0dcf7e6164c76dc36d1a1fb7d249e6
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-linux-amd64-1.3.7
+  - checksum: a313e724cf2277b8f79ad75e7005a79d69b75135
     platform: linux32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.6/metric-registrar-cli-linux-386-1.3.6
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-linux-386-1.3.7
   company: VMware
   created: 2018-10-04T18:21:00Z
   description: Allow users to register metric sources.
   homepage: https://github.com/pivotal-cf/metric-registrar-cli
   name: metric-registrar
-  updated: 2022-10-19T00:00:00Z
-  version: 1.3.6
+  updated: 2022-11-08T00:00:00Z
+  version: 1.3.7
 - authors:
   - contact: dimitar.donchev@sap.com
     name: Dimitar Donchev


### PR DESCRIPTION
- Built with Go 1.19.3

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [X] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [X] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

## Description of the Change

Bumps Go to 1.19.3.