### PR TITLE
Update html5-plugin to 1.4.7

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1008,13 +1008,13 @@ plugins:
     homepage: https://github.com/micellius
     name: micellius
   binaries:
-  - checksum: null
+  - checksum: 0e1175979153e6b49f6ef6c5574ca8b1e1ea87f6
     platform: osx
     url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-darwin-amd64
-  - checksum: null
+  - checksum: b267df45afc6287b3ac578f2973aa2c842f08179
     platform: linux64
     url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-linux-amd64
-  - checksum: null
+  - checksum: 7200a691af14f3db79f1992789c0a349c6d3a474
     platform: win64
     url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-windows-amd64.exe
   company: SAP

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1008,22 +1008,22 @@ plugins:
     homepage: https://github.com/micellius
     name: micellius
   binaries:
-  - checksum: 6a78d6b44720b21c9ac103d18abdec84bd4a1cd1
+  - checksum: null
     platform: osx
-    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.6/cf-html5-apps-repo-cli-plugin-darwin-amd64
-  - checksum: 32210813f17aa1cc9c4c2a5fab9fee64ef33eb83
+    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-darwin-amd64
+  - checksum: null
     platform: linux64
-    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.6/cf-html5-apps-repo-cli-plugin-linux-amd64
-  - checksum: 4420299058fee1c7e62fe8032803f9538b3a31d3
+    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-linux-amd64
+  - checksum: null
     platform: win64
-    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.6/cf-html5-apps-repo-cli-plugin-windows-amd64.exe
+    url: https://github.com/SAP/cf-html5-apps-repo-cli-plugin/releases/download/v1.4.7/cf-html5-apps-repo-cli-plugin-windows-amd64.exe
   company: SAP
   created: 2019-02-05T12:00:00Z
   description: CLI client for SAP Cloud Platform HTML5 Applications Repository service
   homepage: https://sap.github.io/cf-html5-apps-repo-cli-plugin
   name: html5-plugin
-  updated: 2021-02-16T14:38:27Z
-  version: 1.4.6
+  updated: 2023-03-02T09:53:57Z
+  version: 1.4.7
 - authors:
   - contact: tim.gerlach@sap.com
     homepage: https://github.com/SAP


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

Upgrade plugin to use CloudFoundry v3 API instead of v2

## Why Is This PR Valuable?

SAP has deprecated use of Cloud Foundry v2 API in SAP BTP Cloud Foundry environment. 
To make sure plugin continue to work after decommission of Cloud Foundry v2 API, all plugin calls to v2 API were replaced with corresponding calls to v3 API.

## Applicable Issues

- https://github.com/SAP/cf-html5-apps-repo-cli-plugin/issues/62

## How Urgent Is The Change?

The change is not time-sensitive and may be handled with medium priority.

## Other Relevant Parties

The change is backward-compatible and other parties should not be affected.
