### PR TITLE
update cli plugins

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1109,22 +1109,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: 8849e61ec98f340a0dded22fc91ab9cca368bf60
+  - checksum: 67c66c0b0946691dc2e81f498fa1c6b431551c29
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-darwin
-  - checksum: 831bbd528af0b62cf7a607ce5437166b3c65fbb1
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.0/log-cache-cf-plugin-darwin
+  - checksum: 5cf53c7fe5172557036d46095f08ab8e3d39755b
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-linux
-  - checksum: 8fd073443ef74eb96b92220c7f737fa25f17f87a
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.0/log-cache-cf-plugin-linux
+  - checksum: 6f143d59af867b3c3d792847a4e1a0adb3f9dc10
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.0/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2023-03-06T00:00:00Z
-  version: 4.0.11
+  updated: 2023-03-30T00:00:00Z
+  version: 5.0.0
 - authors:
   - name: CF Loggregator Team
   binaries:

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1109,22 +1109,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: e14f3f4782ad7b706fc3fdad42f6e6abe43432dc
+  - checksum: 8849e61ec98f340a0dded22fc91ab9cca368bf60
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.9/log-cache-cf-plugin-darwin
-  - checksum: d969d8b6b23713b9cf1821cc015dd5a1592ddef6
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-darwin
+  - checksum: 831bbd528af0b62cf7a607ce5437166b3c65fbb1
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.9/log-cache-cf-plugin-linux
-  - checksum: eba13890491ef2cab5f548f483a111f15f6d81a9
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-linux
+  - checksum: 8fd073443ef74eb96b92220c7f737fa25f17f87a
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.9/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v4.0.11/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2022-11-07T00:00:00Z
-  version: 4.0.9
+  updated: 2023-03-06T00:00:00Z
+  version: 4.0.11
 - authors:
   - name: CF Loggregator Team
   binaries:
@@ -1221,28 +1221,28 @@ plugins:
 - authors:
   - name: CF Metric Registrar Team
   binaries:
-  - checksum: ac07123172b50265887dccadeecaf3a40273f50c
+  - checksum: ab733e1d81d0a36fa8079c7682f348199ccd6e5e
     platform: osx
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-darwin-amd64-1.3.7
-  - checksum: d9c1140de72550801568233cebc9d26ba95454b2
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-darwin-amd64-1.3.8
+  - checksum: 8092156fd2e574108a83564d04b9127b995aa326
     platform: win64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-windows-amd64-1.3.7
-  - checksum: a37a779a248d254fc0bd7e110fe7d8aedaa12396
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-windows-amd64-1.3.8
+  - checksum: 1f67bedcb61e4c608f35b307b9a4820031f77ef3
     platform: win32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-windows-386-1.3.7
-  - checksum: daba53e7610d18c328e5dede8ddb4b9584a6f8d4
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-windows-386-1.3.8
+  - checksum: 706e34614275b4bed3005c781b0b23ca09fdad06
     platform: linux64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-linux-amd64-1.3.7
-  - checksum: a313e724cf2277b8f79ad75e7005a79d69b75135
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-linux-amd64-1.3.8
+  - checksum: 05b8576dee523147132f6650cbd21e53a1783125
     platform: linux32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.7/metric-registrar-cli-linux-386-1.3.7
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-linux-386-1.3.8
   company: VMware
   created: 2018-10-04T18:21:00Z
   description: Allow users to register metric sources.
   homepage: https://github.com/pivotal-cf/metric-registrar-cli
   name: metric-registrar
-  updated: 2022-11-08T00:00:00Z
-  version: 1.3.7
+  updated: 2023-03-06T00:00:00Z
+  version: 1.3.8
 - authors:
   - contact: dimitar.donchev@sap.com
     name: Dimitar Donchev


### PR DESCRIPTION
## Description of the Change
* update golang for the two plugins we manage
* include a major improvement to functionality to the log-cache plugin. Users can now use the --json flag on tail and be able to actually read their logs. 

## Why Is This PR Valuable?

new golang versions
