### PR TITLE
Bump metric-registrar-cli to 1.3.10

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1221,28 +1221,28 @@ plugins:
 - authors:
   - name: CF Metric Registrar Team
   binaries:
-  - checksum: ab733e1d81d0a36fa8079c7682f348199ccd6e5e
+  - checksum: 668c9800fd477cdb90e35e1470aef49ab6b46978
     platform: osx
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-darwin-amd64-1.3.8
-  - checksum: 8092156fd2e574108a83564d04b9127b995aa326
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.10/metric-registrar-cli-darwin-amd64-1.3.10
+  - checksum: 8ebce8e24d9680728cc9a6bffaaadcd8fbcf8576
     platform: win64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-windows-amd64-1.3.8
-  - checksum: 1f67bedcb61e4c608f35b307b9a4820031f77ef3
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.10/metric-registrar-cli-windows-amd64-1.3.10
+  - checksum: 59a8a0adc46b3921974ed037227219fee8d22b12
     platform: win32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-windows-386-1.3.8
-  - checksum: 706e34614275b4bed3005c781b0b23ca09fdad06
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.10/metric-registrar-cli-windows-386-1.3.10
+  - checksum: b8315a4ac821e5367420026e02bbc44e47448305
     platform: linux64
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-linux-amd64-1.3.8
-  - checksum: 05b8576dee523147132f6650cbd21e53a1783125
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.10/metric-registrar-cli-linux-amd64-1.3.10
+  - checksum: d5737ea8be5eadbf37a10c04308e3a04a99852ba
     platform: linux32
-    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/v1.3.8/metric-registrar-cli-linux-386-1.3.8
+    url: https://github.com/pivotal-cf/metric-registrar-cli/releases/download/1.3.10/metric-registrar-cli-linux-386-1.3.10
   company: VMware
   created: 2018-10-04T18:21:00Z
   description: Allow users to register metric sources.
   homepage: https://github.com/pivotal-cf/metric-registrar-cli
   name: metric-registrar
-  updated: 2023-03-06T00:00:00Z
-  version: 1.3.8
+  updated: 2023-05-04T00:00:00Z
+  version: 1.3.10
 - authors:
   - contact: dimitar.donchev@sap.com
     name: Dimitar Donchev


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [X] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [X] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

## Why Is This PR Valuable?

Bumps the plugin to go1.20.4.

## Applicable Issues

None.

## How Urgent Is The Change?

Non-urgent.

## Other Relevant Parties

None.