### PR TITLE
Bump log-cache to 5.0.3

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1109,22 +1109,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: ce7af606d83278a688006f5b344f58ca8a5c1db4
+  - checksum: d5c48621c85af6612c66ba12e0c06210b9071e8b
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.1/log-cache-cf-plugin-darwin
-  - checksum: f9f2e037c42e64594eb5ac2be6d0c58b304126f4
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-darwin
+  - checksum: 316d2a036e769f6dffde3ea91b682d8a714796eb
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.1/log-cache-cf-plugin-linux
-  - checksum: 0403fb9738c9117480386c75b3268dabb092b965
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-linux
+  - checksum: 3666130efe932915f2afc42bd2f77f362b296a32
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.1/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2023-05-04T00:00:00Z
-  version: 5.0.1
+  updated: 2023-08-30T00:00:00Z
+  version: 5.0.3
 - authors:
   - name: CF Loggregator Team
   binaries:


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

Bump log-cache to 5.0.3

## Why Is This PR Valuable?

Regular security patch

## Applicable Issues

None

## How Urgent Is The Change?

Not that urgent

## Other Relevant Parties

@rroberts2222 