### PR TITLE
Bump log-cache to v5.0.4

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1109,22 +1109,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: d5c48621c85af6612c66ba12e0c06210b9071e8b
+  - checksum: ff12e09358b2a2de7bb7ab72c5a221c941584b2b
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-darwin
-  - checksum: 316d2a036e769f6dffde3ea91b682d8a714796eb
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.4/log-cache-cf-plugin-darwin
+  - checksum: 071ca1d821d06af52490406a2793fb306f336400
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-linux
-  - checksum: 3666130efe932915f2afc42bd2f77f362b296a32
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.4/log-cache-cf-plugin-linux
+  - checksum: 2f75132ccf227cc08e722fc51e194ef199c562a0
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.4/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2023-08-30T00:00:00Z
-  version: 5.0.3
+  updated: 2023-09-08T00:00:00Z
+  version: 5.0.4
 - authors:
   - name: CF Loggregator Team
   binaries:


### PR DESCRIPTION
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

## Description of the Change

Bump log-cache to [v5.0.4](https://github.com/cloudfoundry/log-cache-cli/releases/tag/v5.0.4).

## Why Is This PR Valuable?

Builds the plugin with go1.20.8.

## How Urgent Is The Change?

Non-urgent.
