### PR TITLE
chore: Remove deprecated cf-drain-cli

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -898,25 +898,6 @@ plugins:
   updated: 2016-02-08T00:00:00Z
   version: 1.0.1
 - authors:
-  - name: CF Loggregator Team
-  binaries:
-  - checksum: 2f4dbf99b4cc31e960599eca298eb982e4195a55
-    platform: osx
-    url: https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-darwin
-  - checksum: 9aa82d816269411cd0e5e6bd65cd610fcd6e2062
-    platform: linux64
-    url: https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-linux
-  - checksum: af088c152cba2f7b6636ce9138342d1882ddd7ad
-    platform: win64
-    url: https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-windows
-  company: Pivotal
-  created: 2018-04-20T00:00:00Z
-  description: A plugin to simplify interactions with user provided syslog drains.
-  homepage: https://github.com/cloudfoundry/cf-drain-cli
-  name: drains
-  updated: 2019-11-06T00:00:00Z
-  version: 2.0.0
-- authors:
   - contact: x@cinaq.com
     homepage: https://github.com/xiwenc
     name: Xiwen Cheng


### PR DESCRIPTION
# Submitting Plugins

Not adding a new plugin.

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

## Description of the Change

Removes the [cf-drain-cli plugin](https://github.com/cloudfoundry/cf-drain-cli), which is deprecated. The repo is archived, and has advertised removal for some time.

## Why Is This PR Valuable?

Removes deprecated plugin from the community list, which should theoretically contain supported, recommended plugins.

## Applicable Issues

None

## How Urgent Is The Change?

Not that urgent

## Other Relevant Parties

Anyone still using this plugin. They should stop using it though.