### PR TITLE
Bump log-cache to v5.0.5

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1109,22 +1109,22 @@ plugins:
 - authors:
   - name: CF Log Cache Team
   binaries:
-  - checksum: d5c48621c85af6612c66ba12e0c06210b9071e8b
+  - checksum: eb2b0689f57af0ad9eef56e5e426de8091bc6a8c
     platform: osx
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-darwin
-  - checksum: 316d2a036e769f6dffde3ea91b682d8a714796eb
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.5/log-cache-cf-plugin-darwin
+  - checksum: 1d3552f24936ac95880d1732afe9024d6fb77701
     platform: linux64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-linux
-  - checksum: 3666130efe932915f2afc42bd2f77f362b296a32
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.5/log-cache-cf-plugin-linux
+  - checksum: 04d4266e5a6c5b1dbd5b681e33bffda68adf5db1
     platform: win64
-    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.3/log-cache-cf-plugin-windows
+    url: https://github.com/cloudfoundry/log-cache-cli/releases/download/v5.0.5/log-cache-cf-plugin-windows
   company: null
   created: 2018-05-18T00:00:00Z
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2023-08-30T00:00:00Z
-  version: 5.0.3
+  updated: 2023-11-14T00:00:00Z
+  version: 5.0.5
 - authors:
   - name: CF Loggregator Team
   binaries:


### PR DESCRIPTION
Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

Bump log-cache plugin to v5.0.5


## Why Is This PR Valuable?

Get latest version of the log-cache plugin

## Applicable Issues

None

## How Urgent Is The Change?

Not that urgent

## Other Relevant Parties

None