### PR TITLE
Fix mismatched versions of log-cache and metric-registrar

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1104,8 +1104,8 @@ plugins:
   description: Allows users to query Log Cache.
   homepage: http://github.com/cloudfoundry/log-cache-cli
   name: log-cache
-  updated: 2023-11-14T00:00:00Z
-  version: 5.0.5
+  updated: 2023-12-07T00:00:00Z
+  version: 5.0.6
 - authors:
   - name: CF Loggregator Team
   binaries:
@@ -1222,8 +1222,8 @@ plugins:
   description: Allow users to register metric sources.
   homepage: https://github.com/pivotal-cf/metric-registrar-cli
   name: metric-registrar
-  updated: 2023-11-14T00:00:00Z
-  version: 1.4.3
+  updated: 2023-12-07T00:00:00Z
+  version: 1.4.4
 - authors:
   - contact: dimitar.donchev@sap.com
     name: Dimitar Donchev


### PR DESCRIPTION
The last update of these two plugins left out the version field. Adding a fix so that the versions now match.

Thank you for contributing to the CF CLI Plugin Repository!

This repo contains both the plugin repo server and the metadata for CLI
community plugins.
Some of the requirements for PRs will apply to only one of these parts.

We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.

# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

# Submitting PRs to CLIPR (the CLI Plugin Repo server)

All new code requires tests to protect against regressions.

## Description of the Change

The last update of these two plugins left out the version field. This PR adds a fix so that the versions now match.

## Why Is This PR Valuable?

Users can get the latest versions of the log-cache and metric-registrar plugins without confusion about which version they are getting.

## Applicable Issues

None

## How Urgent Is The Change?

Not that urgent, but the mismatching versions may be confusing for users when using the CLI.

## Other Relevant Parties

None
