### PR TITLE
Bump cf java plugin version to version 3.0.3

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1017,19 +1017,19 @@ plugins:
     homepage: https://github.com/SAP
     name: Tim Gerlach
   binaries:
-  - checksum: ef4bb0a266b12dc1e86fae12bc51bf8313e9dced
+  - checksum: 78fc1166762ac5ff63112a659162d10ecadaf539
     platform: osx
     url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-osx
-  - checksum: 9b045a86e5a73a1955736d7f911e23bff0b454cd
+  - checksum: c1abc29a203e1d053057a96c216ffd99a4ac9acc
     platform: win64
     url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-win64.exe
-  - checksum: 3c01ff15121ae95a516c5e8c5c16ae3527eed699
+  - checksum: 9fcbd37499edf30bdf68cb5218f0686cd25947a4
     platform: win32
     url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-win32.exe
-  - checksum: 530bb4f46e7ef18b75de975d636ef09703d497dc
+  - checksum: 40e595ca1a1a5d1762c247752d06f9f84aecf52c
     platform: linux32
     url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-linux32
-  - checksum: 827e34ba4ca24e62931c0b686e4b7d47ecd956af
+  - checksum: a285fe5b3834c8d0abca4a3c7966e830930b7e14
     platform: linux64
     url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-linux64
   company: SAP
@@ -1038,8 +1038,8 @@ plugins:
     application.
   homepage: https://github.com/SAP/cf-cli-java-plugin
   name: java
-  updated: "2024-06-11T00:00:00Z"
-  version: 3.0.2
+  updated: "2024-08-12T00:00:00Z"
+  version: 3.0.3
 - authors:
   - contact: drnic@starkandwayne.com
     homepage: http://drnicwilliams.com


### PR DESCRIPTION
Includes fix for container selection of heap dump source.