### PR TITLE
Fix outdated download URL of java plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1019,19 +1019,19 @@ plugins:
   binaries:
   - checksum: 78fc1166762ac5ff63112a659162d10ecadaf539
     platform: osx
-    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-osx
+    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.3/cf-cli-java-plugin-osx
   - checksum: c1abc29a203e1d053057a96c216ffd99a4ac9acc
     platform: win64
-    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-win64.exe
+    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.3/cf-cli-java-plugin-win64.exe
   - checksum: 9fcbd37499edf30bdf68cb5218f0686cd25947a4
     platform: win32
-    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-win32.exe
+    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.3/cf-cli-java-plugin-win32.exe
   - checksum: 40e595ca1a1a5d1762c247752d06f9f84aecf52c
     platform: linux32
-    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-linux32
+    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.3/cf-cli-java-plugin-linux32
   - checksum: a285fe5b3834c8d0abca4a3c7966e830930b7e14
     platform: linux64
-    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.2/cf-cli-java-plugin-linux64
+    url: https://github.com/SAP/cf-cli-java-plugin/releases/download/3.0.3/cf-cli-java-plugin-linux64
   company: SAP
   created: "2017-03-14T09:00:00Z"
   description: Obtain a heap dump or thread dump from a running, SSH-enabled Java


### PR DESCRIPTION
Sorry for the follow-up of #484.
While I did update the checksums, I forgot to update the download URL.