### PR TITLE
Fix wiki link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,18 @@ approval, please submit a pull request according to the guidelines below.
   ```
   Please make sure the spacing and colons are correct and that the fields are alphabetized in the entry. The following describes each field's usage.
 
+[iso8601]: https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations
+
   Field | Description
   ------ | ---------
   `authors` | Fields to detail the authors of the plugin<br>`name`: name of author<br>`homepage`: **Optional** link to the homepage of the author<br>`contact`: **Optional** ways to contact author, email, twitter, phone etc ...
   `binaries` | This section has fields detailing the various binary versions of your plugin. To reach as large an audience as possible, we encourage contributors to cross-compile their plugins on as many platforms as possible. Go provides everything you need to cross-compile for different platforms<br>`platform`: The os for this binary. Supports `osx`, `linux32`, `linux64`, `win32`, `win64`<br>`url`: A versioned HTTPS link to the binary file itself<br>`checksum`: SHA-1 of the binary file for verification<br>**Use a unique URL that includes the release version** for each release of your plugin, as each binary will have a unique checksum.
   `company` | **Optional** field detailing company or organization that created the plugin
-  `created` | date of first submission of the plugin, in [iso 8601 combined date and time with timezone format](https://en.wikipedia.org/wiki/iso_8601#combined_date_and_time_representations)
+  `created` | date of first submission of the plugin, in [iso 8601 combined date and time with timezone format][iso8601]
   `description` | describe your plugin in a line or two. this description will show up when your plugin is listed on the command line
   `homepage` | Link to the homepage where the source code is hosted. Currently we only support open source plugins
   `name` | name of your plugin, must not conflict with other existing plugins in the repo. **It must also match the name your plugin returns.**
-  `updated` | Date of last update of the plugin, in [ISO 8601 Combined Date and Time with Timezone Format](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
+  `updated` | Date of last update of the plugin, in [ISO 8601 Combined Date and Time with Timezone Format][iso8601]
   `version` | version number of your plugin, in [major].[minor].[build] form
 
 1. run `go run sort/main.go repo-index.yml`. This will sort your additions to the file.


### PR DESCRIPTION
One of the links to Wikipedia about ISO 8601 needed to be fixed.  There were case differences.    This PR makes the URL portion sharable between the two references.