### PR TITLE
Add the stack auditor, a plugin that helps operators know which stacks are in use on the platform, to the cli plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1676,6 +1676,26 @@ plugins:
   name: spring-cloud-dataflow-for-pcf
   updated: "2020-03-04T09:47:00Z"
   version: 1.0.2
+- binaries:
+  - checksum: 37ce03d3e76b7ef671e6f7b1fbfbd0f3793f55c1
+    platform: osx
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-amd64
+  - checksum: 9284458fd08dc9eee31c61134253d68d58bb91ad
+    platform: osx
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-arm
+  - checksum: 88810ae36c38dcec0679471493c49dd15a3f6168
+    platform: linux64
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-linux-64
+  - checksum: d269b6e427c2459f7197ed2eed4ccb3f65e47540
+    platform: win64
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-windows-64
+  company: Broadcom
+  created: "2024-08-20T09:19:00Z"
+  description: Listing apps and their stacks, migrating apps to a new stack, and deleting a stack
+  homepage: https://github.com/cloudfoundry/stack-auditor
+  name: StackAuditor
+  updated: "2024-08-20T09:19:00Z"
+  version: 0.1.2
 - authors:
   - contact: cf-spring-cloud-services@pivotal.io
     homepage: https://docs.pivotal.io/spring-cloud-services

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1676,7 +1676,9 @@ plugins:
   name: spring-cloud-dataflow-for-pcf
   updated: "2020-03-04T09:47:00Z"
   version: 1.0.2
-- binaries:
+- authors:
+  - name: stack-auditor team
+  binaries:
   - checksum: 37ce03d3e76b7ef671e6f7b1fbfbd0f3793f55c1
     platform: osx
     url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-amd64

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1677,7 +1677,7 @@ plugins:
   updated: "2020-03-04T09:47:00Z"
   version: 1.0.2
 - authors:
-  - name: stack-auditor team
+  - name: Stack Auditor Team
   binaries:
   - checksum: 37ce03d3e76b7ef671e6f7b1fbfbd0f3793f55c1
     platform: osx

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1677,28 +1677,6 @@ plugins:
   updated: "2020-03-04T09:47:00Z"
   version: 1.0.2
 - authors:
-  - name: Stack Auditor Team
-  binaries:
-  - checksum: 37ce03d3e76b7ef671e6f7b1fbfbd0f3793f55c1
-    platform: osx
-    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-amd64
-  - checksum: 9284458fd08dc9eee31c61134253d68d58bb91ad
-    platform: osx
-    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-arm
-  - checksum: 88810ae36c38dcec0679471493c49dd15a3f6168
-    platform: linux64
-    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-linux-64
-  - checksum: d269b6e427c2459f7197ed2eed4ccb3f65e47540
-    platform: win64
-    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-windows-64
-  company: Broadcom
-  created: "2024-08-20T09:19:00Z"
-  description: Listing apps and their stacks, migrating apps to a new stack, and deleting a stack
-  homepage: https://github.com/cloudfoundry/stack-auditor
-  name: StackAuditor
-  updated: "2024-08-20T09:19:00Z"
-  version: 0.1.2
-- authors:
   - contact: cf-spring-cloud-services@pivotal.io
     homepage: https://docs.pivotal.io/spring-cloud-services
     name: spring-cloud-services
@@ -1728,6 +1706,29 @@ plugins:
   name: spring-cloud-services
   updated: "2024-07-26T09:19:00Z"
   version: 1.0.26
+- authors:
+  - name: Stack Auditor Team
+  binaries:
+  - checksum: 37ce03d3e76b7ef671e6f7b1fbfbd0f3793f55c1
+    platform: osx
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-amd64
+  - checksum: 9284458fd08dc9eee31c61134253d68d58bb91ad
+    platform: osx
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-darwin-arm
+  - checksum: 88810ae36c38dcec0679471493c49dd15a3f6168
+    platform: linux64
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-linux-64
+  - checksum: d269b6e427c2459f7197ed2eed4ccb3f65e47540
+    platform: win64
+    url: https://github.com/cloudfoundry/stack-auditor/releases/download/v0.1.2/stack-auditor-windows-64
+  company: Broadcom
+  created: "2024-08-20T09:19:00Z"
+  description: Listing apps and their stacks, migrating apps to a new stack, and deleting
+    a stack
+  homepage: https://github.com/cloudfoundry/stack-auditor
+  name: StackAuditor
+  updated: "2024-08-20T09:19:00Z"
+  version: 0.1.2
 - authors:
   - contact: mark.webb@cgi.com
     name: Mark Webb


### PR DESCRIPTION
# Submitting Plugins

If you haven't yet, please review our contributing guidelines:  
https://github.com/cloudfoundry/cli-plugin-repo#submitting-plugins

In particular ensure the following requirements are being met:
* [x] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [x] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field

## Description of the Change

Add the stack auditor, a plugin that helps operators know which stacks are in use on the platform, to the cli plugin registry
