### PR TITLE
Bump app-autoscaler-cli-plugin to v4.0.1

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -47,23 +47,23 @@ plugins:
   - homepage: https://github.com/orgs/cloudfoundry/teams/wg-app-runtime-interfaces-autoscaler-approvers
     name: WG App Runtime Interfaces Autoscaler Approvers
   binaries:
-  - checksum: de63f693da9d821301ab928f097b33fcdba53e6a
+  - checksum: ad9103529040feccf86aff84d2e9d5a5ff0970bb
     platform: osx
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v3.0.1/ascli-darwin-amd64-3.0.1-release+0
-  - checksum: 771d7d0c565d96c6c49bb6f6f28de603ac4c7e83
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.0.1/ascli-darwin-amd64-4.0.1-release+0
+  - checksum: c95b046c035ecfbba7af32899de9995944034072
     platform: linux64
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v3.0.1/ascli-linux-amd64-3.0.1-release+0
-  - checksum: 2c5766b6f9b4e8ebd7e9d16c033aa51375c78ec9
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.0.1/ascli-linux-amd64-4.0.1-release+0
+  - checksum: fe45bef207a10c892bf1a94942537f864ff230d9
     platform: win64
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v3.0.1/ascli-windows-amd64-3.0.1-release+0.exe
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.0.1/ascli-windows-amd64-4.0.1-release+0.exe
   company: Cloud Foundry Foundation
   created: "2018-04-17T00:00:00Z"
   description: App-AutoScaler plug-in provides the command line interface to manage
     App AutoScaler service policies, retrieve metrics and scaling history.
   homepage: https://github.com/cloudfoundry/app-autoscaler-cli-plugin
   name: app-autoscaler-plugin
-  updated: "2024-08-22T10:38:29Z"
-  version: 3.0.1
+  updated: "2024-08-30T15:29:00Z"
+  version: 4.0.1
 - authors:
   - contact: warren.f.fernandes@gmail.com
     homepage: https://github.com/wfernandes


### PR DESCRIPTION
This is an automated commit to bump app-autoscaler-cli-plugin to [v4.0.1](https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/tag/v4.0.1).

This release moves the plugin from using the Cloud Foundry API v2 to v3. 🎉

It also removes some commands that were not supported by app-autoscaler-release since [v13](https://github.com/cloudfoundry/app-autoscaler-release/releases/tag/v13.0.0), which is why it gets a new major version.
