### PR TITLE
Cloud Foundry Route Lookup Plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -343,6 +343,12 @@ plugins:
   - contact: daria.anton@sap.com
     homepage: https://github.com/Dariquest
     name: Daria Anton
+  - contact: alexander.lais@sap.com
+    homepage: https://github.com/peanball
+    name: Alexander Lais
+  - contact: maximilian.moehl@sap.com
+    homepage: https://github.com/maxmoehl
+    name: Maximilian Möhl   
   binaries:
   - checksum: 2d99d58385d6754d7cabfcccefce1e2b8d626a26
     platform: osx
@@ -363,7 +369,7 @@ plugins:
   created: "2024-11-22T00:00:00Z"
   description: CF Route Lookup Plugin to identify applications, a given route is pointing
     to.
-  homepage: https://github.com/https://github.com/cloudfoundry/cf-lookup-route
+  homepage: https://github.com/cloudfoundry/cf-lookup-route
   name: cf-lookup-route
   updated: "2024-11-22T00:00:00Z"
   version: 0.0.1

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -352,19 +352,19 @@ plugins:
   binaries:
   - checksum: 2d99d58385d6754d7cabfcccefce1e2b8d626a26
     platform: osx
-    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.osx
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/0.1.0/cf-lookup-route.osx
   - checksum: 9cfc9d769fcdcfec7670d051d6ceb5993852a6ca
     platform: linux64
-    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.linux64
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/0.1.0/cf-lookup-route.linux64
   - checksum: 49fe70ea7fe3fae413a404fb6fd77374afa190c1
     platform: linux32
-    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.linux32
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/0.1.0/cf-lookup-route.linux32
   - checksum: e41f8e597524a67303dd7469adcdebeb4ed2a7c9
     platform: win32
-    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.win32
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/0.1.0/cf-lookup-route.win32
   - checksum: d050f56b6cd6510032bc3f86157e245ff5fe0b0e
     platform: win64
-    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.win64
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/0.1.0/cf-lookup-route.win64
   company: Cloud Foundry Foundation
   created: "2024-11-22T00:00:00Z"
   description: CF Route Lookup Plugin to identify applications, a given route is pointing
@@ -372,7 +372,7 @@ plugins:
   homepage: https://github.com/cloudfoundry/cf-lookup-route
   name: cf-lookup-route
   updated: "2024-11-22T00:00:00Z"
-  version: 0.0.1
+  version: 0.1.0
 - authors:
   - contact: stanislav.turlo@altoros.com
     homepage: https://github.com/nobodyzzz

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -346,7 +346,7 @@ plugins:
   - contact: alexander.lais@sap.com
     homepage: https://github.com/peanball
     name: Alexander Lais
-  - contact: maximilian.moehl@sap.com
+  - contact: cf@moehl.eu
     homepage: https://github.com/maxmoehl
     name: Maximilian Möhl
   binaries:

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -340,6 +340,34 @@ plugins:
   updated: "2017-04-04T00:00:00Z"
   version: 0.0.11
 - authors:
+  - contact: daria.anton@sap.com
+    homepage: https://github.com/Dariquest
+    name: Daria Anton
+  binaries:
+  - checksum: 2d99d58385d6754d7cabfcccefce1e2b8d626a26
+    platform: osx
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.osx
+  - checksum: 9cfc9d769fcdcfec7670d051d6ceb5993852a6ca
+    platform: linux64
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.linux64
+  - checksum: 49fe70ea7fe3fae413a404fb6fd77374afa190c1
+    platform: linux32
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.linux32
+  - checksum: e41f8e597524a67303dd7469adcdebeb4ed2a7c9
+    platform: win32
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.win32
+  - checksum: d050f56b6cd6510032bc3f86157e245ff5fe0b0e
+    platform: win64
+    url: https://github.com/cloudfoundry/cf-lookup-route/releases/download/v0.0.1/cf-lookup-route.win64
+  company: Cloud Foundry Foundation
+  created: "2024-11-22T00:00:00Z"
+  description: CF Route Lookup Plugin to identify applications, a given route is pointing
+    to.
+  homepage: https://github.com/https://github.com/cloudfoundry/cf-lookup-route
+  name: cf-lookup-route
+  updated: "2024-11-22T00:00:00Z"
+  version: 0.0.1
+- authors:
   - contact: stanislav.turlo@altoros.com
     homepage: https://github.com/nobodyzzz
     name: Stanislav Turlo

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -348,7 +348,7 @@ plugins:
     name: Alexander Lais
   - contact: maximilian.moehl@sap.com
     homepage: https://github.com/maxmoehl
-    name: Maximilian Möhl   
+    name: Maximilian Möhl
   binaries:
   - checksum: 2d99d58385d6754d7cabfcccefce1e2b8d626a26
     platform: osx

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -348,7 +348,7 @@ plugins:
     name: Alexander Lais
   - contact: cf@moehl.eu
     homepage: https://github.com/maxmoehl
-    name: Maximilian Möhl
+    name: Maximilian Moehl
   binaries:
   - checksum: 2d99d58385d6754d7cabfcccefce1e2b8d626a26
     platform: osx


### PR DESCRIPTION
# Cloud Foundry Route Lookup Plugin

This is a Cloud Foundry CLI plugin to quickly identify applications, a given route is pointing to.
Note this will only show applications in organizations and spaces, that the logged-in user has permissions to view.
The plugin also supports targeting to the organization and space of the applications, a given route is pointing to.

## Usage Sample
```
$ cf lookup-route <my.example.com>
Bound to:
Organization: <org> (<org_guid>)
Space       : <space> (<space_guid>)
App         : <app1> (<app_guid_1>)
App         : <app2> (<app_guid_2>)
```

## Why Is This PR Valuable?

* There are multiple scenarios, where users wish to quickly search for all the apps bound to a certain route, target the corresponding org and space of the apps to perform some changes there (e.g. list or add users).
* This plugin uses CF API v3. 

TO DOs
* [X] The plugin's `name` field in `repo-index.yml` matches the `Name` field in the plugin's `plugin.PluginMetadata` section
* [X] The plugin's `url` field in `repo-index.yml` contains the same version from the `version` field