### PR TITLE
Bump app-autoscaler-cli-plugin to v4.1.1

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -47,23 +47,23 @@ plugins:
   - homepage: https://github.com/orgs/cloudfoundry/teams/wg-app-runtime-interfaces-autoscaler-approvers
     name: WG App Runtime Interfaces Autoscaler Approvers
   binaries:
-  - checksum: 2beb714f5555120d053e13ee0716f9e60bae8b36
+  - checksum: 5121719045526ba10ac8bfa7ca0004b128f801dc
     platform: osx
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.0/ascli-darwin-amd64-4.1.0-release+0
-  - checksum: 29d72d1f2cf4e79467bfcff9e4b681199360fa84
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.1/ascli-darwin-amd64-4.1.1-release+0
+  - checksum: 719beb0379bc1f406a5785e4f451523078f0146d
     platform: linux64
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.0/ascli-linux-amd64-4.1.0-release+0
-  - checksum: b1d98db84115bc9c0b8233905e493122dd44db07
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.1/ascli-linux-amd64-4.1.1-release+0
+  - checksum: 439e1eea39f4b09fafa51d1c908ff067eda2fa3b
     platform: win64
-    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.0/ascli-windows-amd64-4.1.0-release+0.exe
+    url: https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/download/v4.1.1/ascli-windows-amd64-4.1.1-release+0.exe
   company: Cloud Foundry Foundation
   created: "2018-04-17T00:00:00Z"
   description: App-AutoScaler plug-in provides the command line interface to manage
     App AutoScaler service policies, retrieve metrics and scaling history.
   homepage: https://github.com/cloudfoundry/app-autoscaler-cli-plugin
   name: app-autoscaler-plugin
-  updated: "2024-12-06T09:24:54Z"
-  version: 4.1.0
+  updated: "2025-04-15T16:17:08Z"
+  version: 4.1.1
 - authors:
   - contact: warren.f.fernandes@gmail.com
     homepage: https://github.com/wfernandes


### PR DESCRIPTION
## Description of the Change

This is an automated commit to bump app-autoscaler-cli-plugin to [v4.1.1](https://github.com/cloudfoundry/app-autoscaler-cli-plugin/releases/tag/v4.1.1).

