### PR TITLE
Update version of multiapps plugin to 3.7.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1257,29 +1257,29 @@ plugins:
   - contact: https://cloudfoundry.slack.com/messages/multiapps-dev
     name: MultiApps dev slack channel
   binaries:
-  - checksum: 7ebb74b8e9463494099ea2e7932146e520c70b40
+  - checksum: d28bf4e034ffbc5549550d29e4b3c43e35f3128b
     platform: osx
-    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.6.0/multiapps-plugin.osx
-  - checksum: 740556c26b3dab6f0f51fb2f087cf260b8e798b5
+    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.7.0/multiapps-plugin.osx
+  - checksum: cd7079149e240a272fe40c6b8fe965cbbe5ff294
     platform: win32
-    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.6.0/multiapps-plugin.win32.exe
-  - checksum: 0e17a3207a609151542ee90a6dba7f39e72aabda
+    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.7.0/multiapps-plugin.win32.exe
+  - checksum: bfc35845757ec4090162f5962bf0f06261bb3256
     platform: win64
-    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.6.0/multiapps-plugin.win64.exe
-  - checksum: 7bb2308cb695e08f94bfb1793e5fb0e0b4031332
+    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.7.0/multiapps-plugin.win64.exe
+  - checksum: ee567fb13fefbb7669fc51d596385132b65b25cd
     platform: linux32
-    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.6.0/multiapps-plugin.linux32
-  - checksum: fba9f4ac479c3765a233070128e204fe585ae084
+    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.7.0/multiapps-plugin.linux32
+  - checksum: 9ec248252e27eb56978c234c83a222036e0ff605
     platform: linux64
-    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.6.0/multiapps-plugin.linux64
+    url: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v3.7.0/multiapps-plugin.linux64
   company: SAP
   created: "2017-10-06T11:41:00Z"
   description: MultiApps cli plugin performing multitarget application(MTA) operations
     in Cloud Foundry, such as deploying, removing, viewing etc.
   homepage: https://github.com/cloudfoundry/multiapps-cli-plugin
   name: multiapps
-  updated: "2025-08-12T13:30:00Z"
-  version: 3.6.0
+  updated: "2025-09-03T13:30:00Z"
+  version: 3.7.0
 - authors:
   - contact: afleig@pivotal.io
     homepage: https://github.com/andreasf


### PR DESCRIPTION
Description of the Change

Release MultiApps CF CLI Plugin v3.7.0.
This PR updates the plugin version in repo-index.yml and provides the corresponding checksums to make the new release available through the CF CLI Plugin Repository.

Why Is This PR Valuable?

Users will be able to download and use the latest v3.7.0 version of the MultiApps plugin via the plugin repository. Keeping the repository up-to-date ensures that users benefit from the latest features, fixes, and improvements.

Release Highlights (v3.7.0)
	•	Improved error messages for cf deploy to display the specific unknown flag when a flag is misspelled.
	•	Added User-Agent header to the MultiApps CLI plugin for end-to-end tracing and insights into plugin usage and customer workflows.

Applicable Issues

N/A

How Urgent Is The Change?

Not urgent, but timely publishing is important so users can adopt the latest release without delays.

Other Relevant Parties

MultiApps CF CLI Plugin users.
