### PR TITLE
Update UpgradeAllServices plugin to v1.6.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1950,19 +1950,19 @@ plugins:
   - name: Felisia Martini
   - name: George Blue
   binaries:
-  - checksum: 3dc1f8a667fc9d61a88d8751ddb6bc4936da2a30
+  - checksum: b2f5d6a6119ab66e13a914497f0c44fc511c96fb
     platform: osx
-    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.5.0/upgrade-all-services-cli-plugin_darwin_amd64
-  - checksum: 89f94c3a2b1954bafd847794a06dc44c49381032
+    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.6.0/upgrade-all-services-cli-plugin_darwin_amd64
+  - checksum: 3361917a670dc27c5e5e2dd1af1f4e92140fe11a
     platform: linux64
-    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.5.0/upgrade-all-services-cli-plugin_linux_amd64
+    url: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/download/v1.6.0/upgrade-all-services-cli-plugin_linux_amd64
   company: null
   created: "2022-07-07T00:00:00Z"
   description: Allows a user to upgrade all the service instances for a service broker
   homepage: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin
   name: UpgradeAllServices
-  updated: "2024-01-14T00:00:00Z"
-  version: 1.5.0
+  updated: "2025-09-30T00:00:00Z"
+  version: 1.6.0
 - authors:
   - contact: jkruck@pivotal.io
     homepage: https://github.com/krujos/


### PR DESCRIPTION
Update to existing plugin

Release details: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin/releases/tag/v1.6.0